### PR TITLE
actions/checkoutにpersist-credentials: falseをセットする

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: dev-hato/actions-create-release@3fe9e0cb947ce3216562869cef89ff3e193e0649 # v0.0.42
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -29,6 +29,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: false
       - uses: dev-hato/actions-format-json-yml@78a2502c69645dbbd3a56168ddc69065e7ee538c # v0.0.81
         with:
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -17,19 +17,18 @@ jobs:
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ steps.generate_token.outputs.token }}
-          persist-credentials: false
       - uses: dev-hato/actions-format-json-yml@78a2502c69645dbbd3a56168ddc69065e7ee538c # v0.0.81
         with:
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: dev-hato/github-actions-cache-cleaner@7951d10ece225d39f225997fbff2d14f6c44bfa1 # v0.0.63
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -44,6 +44,7 @@ jobs:
           # Full git history is needed to get a proper list
           # of changed files within `super-linter`
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           cache: npm

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:

--- a/.github/workflows/update-dockle.yml
+++ b/.github/workflows/update-dockle.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: ./
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:

--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:


### PR DESCRIPTION
https://zenn.dev/shunsuke_suzuki/articles/github-action-checkout-persist-credentials

`actions/checkout` で使ったtokenが後続のstepで使われないよう、 `persist-credentials: false` をセットします。

また、GitHub Appでのtoken生成処理に関して以下を行います。
* checkout時のtokenをデフォルトのものにする
* GitHub Appでtokenを生成するタイミングをtokenを使用する直前にする