### PR TITLE
node-fetchダウングレード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@proofdict/textlint-rule-proofdict": "3.1.2",
         "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
+        "node-fetch": "2.6.12",
         "textlint": "14.7.1",
         "textlint-filter-rule-comments": "1.2.2",
         "textlint-rule-abbr-within-parentheses": "1.0.2",
@@ -4277,9 +4278,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
+    "node-fetch": "2.6.12",
     "textlint": "14.7.1",
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-abbr-within-parentheses": "1.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>dev-hato/renovate-config"]
+  "extends": ["github>dev-hato/renovate-config"],
+  "ignoreDeps": [
+    "node-fetch"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": [
-    "node-fetch"
-  ]
+  "ignoreDeps": ["node-fetch"]
 }


### PR DESCRIPTION
https://github.com/dev-hato/actions-update-dockle/pull/1720 や https://github.com/dev-hato/actions-update-dockle/pull/1722 でsuper-linterの実行が終わらなくなっているので、 https://github.com/dev-hato/hato-atama/pull/3551 と同様に `node-fetch` を2.6.12で固定します。