### PR TITLE
fix: TypeScriptのtscエラーを修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,13 @@
   "compilerOptions": {
     "target": "es2018",
     "module": "commonjs",
+    "rootDir": "./src",
     "outDir": "./dist/",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "include": ["src/*.ts"]
 }


### PR DESCRIPTION
https://github.com/dev-hato/actions-update-dockle/actions/runs/23602249211/job/69516945779

```
Error: tsconfig.json(5,5): error TS5011: The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
```

```
Error: tsconfig.json(10,25): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

上記エラーを修正するため、以下を行います。

- TS5011: rootDirが未設定だったため `"rootDir": "./src"` を追加
- TS5107: `moduleResolution: "node"` (node10の別名) が非推奨のため `"bundler"` に変更